### PR TITLE
Fix sorting of articles in /nyheter page

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/pages/nyheter/index.tsx
+++ b/pages/nyheter/index.tsx
@@ -66,15 +66,21 @@ const Index = ({ articles }: Props) => {
         <Container>
           <Sidebar />
           <ArticleList>
-            {articles.map((article) => (
-              <ArticleSummary
-                key={article.slug}
-                date={article.data.publishedDate}
-                slug={article.slug}
-                title={article.data.title}
-                content={article.data.summary}
-              ></ArticleSummary>
-            ))}
+            {articles
+              .sort((a, b) => {
+                const dateA = new Date(a.data.publishedDate).getMilliseconds();
+                const dateB = new Date(b.data.publishedDate).getMilliseconds();
+                return dateB - dateA;
+              })
+              .map((article) => (
+                <ArticleSummary
+                  key={article.slug}
+                  date={article.data.publishedDate}
+                  slug={article.slug}
+                  title={article.data.title}
+                  content={article.data.summary}
+                ></ArticleSummary>
+              ))}
           </ArticleList>
         </Container>
       </motion.div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "incremental": true
   },
   "exclude": ["node_modules"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]


### PR DESCRIPTION
Artikler på /nyheter-siden ble ikke sortert og vises nå i samme rekkefølge som de ligger i articles-mappen.

Sorterer de nå basert på publisert dato, med nyeste artikkel øverst.

Hvordan teste:
1. Åpne /nyheter og sjekk at artiklene er sortert i riktig rekkefølge